### PR TITLE
Makefile 구현 성공!(inlcude 경로 수정, 모든 Makefile 내부 수정)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,23 +7,38 @@ BUILD_DIRs = ${DIRs}
 
 CC = gcc
 CFLAGS = -g -W -Wall -o
-EXEs = system/system_server.o\
-	 ui/gui.o \
-	 ui/input.o \
-	 web_server/web_server.o
+CFLAGS_c = -g -W -Wall -c      #obj file 생성까지만 => linking 수행X -> 헤더파일 신경X
+
+OBJs = ./system/system_server.o\
+	 ./ui/gui.o \
+	 ./ui/input.o \
+	 ./web_server/web_server.o \
+	 main.o
+
+INCs = ./system/system_server.h \
+	./ui/gui.h \
+	./ui/input.h \
+	./web_server/web_server.h
+
+SRCs = main.c
 
 #2. targets
-all : 
+all : main.o
 	#sub directory별로 build
 	@ echo ${BUILD_DIRs}
 	@ for dir in ${BUILD_DIRs}; \
 	do \
 		(cd $${dir}; ${MAKE}); \
 		if test $$? -ne @; then break; fi; done
-	
+			
 	#최종 실행파일 build 
-	${CC} ${CFLAGS} toy_system ${EXEs}   
- 		
+	${CC} ${CFLAGS} toy_system ${OBJs}   
+
+
+##main obj file 생성 
+main.o : ${SRCs} ${INCs} 
+	${CC} ${CFLAGS_c} main.o ${SRCs}
+		
 #3. clean
 clean : 
 	#sub directory에서 생성된 실행파일 삭제 
@@ -32,7 +47,7 @@ clean :
 		(cd $${dir}; ${MAKE} clean); done
 	
 	#최종 실행파일 삭제
-	rm -rf toy_system		    
+	rm -rf main.o toy_system		    
 
 
  

--- a/main.c
+++ b/main.c
@@ -1,10 +1,10 @@
 #include <stdio.h>
 #include <sys/wait.h>
 
-#include <system_server.h>
-#include <gui.h>
-#include <input.h>
-#include <web_server.h>
+#include "./system/system_server.h"
+#include "./ui/gui.h"
+#include "./ui/input.h"
+#include "./web_server/web_server.h"
 
 int main()
 {

--- a/system/Makefile
+++ b/system/Makefile
@@ -8,16 +8,22 @@
 
 #1. Macros
 CC = gcc
-CFLAGS = -g -W -Wall -o
-SRC = system_server.c \
-	system_server.h         
+CFLAGS_c = -g -W -Wall -c
+
+SRCs = system_server.c #\
+	system_server.h
+
+INCs = system_server.h \
+	./../ui/gui.h \
+	./../ui/input.h \
+	./../web_server/web_server.h         
 
 #2. targets
 all : system_server.o
 	
 
-system_server.o : ${SRC}
-	${CC} ${CFLAGS} system_server.o ${SRC}
+system_server.o : ${SRCs} ${INCs}
+	${CC} ${CFLAGS_c} system_server.o ${SRCs}
 
 #3. clean
 clean :

--- a/system/system_server.c
+++ b/system/system_server.c
@@ -1,16 +1,17 @@
 #include <stdio.h>
 #include <sys/prctl.h>
 
-#include <system_server.h>
-#include <gui.h>
-#include <input.h>
-#include <web_server.h>
+#include "system_server.h"
+#include "./../ui/gui.h"
+#include "./../ui/input.h"
+#include "./../web_server/web_server.h"
 
 int system_server()
 {
     printf("나 system_server 프로세스!\n");
 
-    while (1) {
+    while (1) 
+    {
         sleep(1);
     }
 

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -8,20 +8,25 @@
 
 #1. Macros
 CC = gcc
-CFLAGS = -g -W -Wall -o
-SRC1 = gui.c \
-	gui.h 
-SRC2 = input.c \
+CFLAGS_c = -g -W -Wall -c
+
+SRC1 = gui.c #\
+	gui.h
+SRC2 = input.c #\
 	input.h 
-	       
+INCs = ./../system/system_server.h \
+	gui.h \
+	input.h \
+	./../web_server/web_server.h
+
 #2. targets
 all : gui.o input.o
 
-gui.o : ${SRC1}
-	${CC} ${CFLAGS} gui.o ${SRC1}
+gui.o : ${SRC1} ${INCs}
+	${CC} ${CFLAGS_c} gui.o ${SRC1}
 
-input.o : ${SRC2}
-	${CC} ${CFLAGS} input.o ${SRC2}
+input.o : ${SRC2} ${INCs}
+	${CC} ${CFLAGS_c} input.o ${SRC2}
 
 
 #3. clean

--- a/ui/gui.c
+++ b/ui/gui.c
@@ -1,10 +1,10 @@
 #include <stdio.h>
 
 //#include <../system/system_server.h>
-#include <system_server.h>
-#include <gui.h>
-#include <input.h>
-#include <web_server.h>
+#include "./../system/system_server.h"
+#include "gui.h"
+#include "input.h"
+#include "./../web_server/web_server.h"
 
 int create_gui()
 {

--- a/ui/input.c
+++ b/ui/input.c
@@ -2,10 +2,10 @@
 #include <sys/prctl.h>
 
 //#include <../system/system_server.h>
-#include <system_server.h>
-#include <gui.h>
-#include <input.h>
-#include <web_server.h>
+#include "./../system/system_server.h"
+#include "gui.h"
+#include "input.h"
+#include "./../web_server/web_server.h"
 
 int input()
 {

--- a/web_server/Makefile
+++ b/web_server/Makefile
@@ -8,16 +8,22 @@
 
 #1. Macros
 CC = gcc
-CFLAGS = -g -W -Wall -o
-SRC = web_server.c \
+CFLAGS_c = -g -W -Wall -c
+
+SRCs = web_server.c #\
 	web_server.h         
+
+INCs = ./../system/system_server.h \
+	./../ui/gui.h \
+	./../ui/input.h \
+	web_server.h
 
 #2. targets
 all : web_server.o
 	
 
-system_server.o : ${SRC}
-	${CC} ${CFLAGS} web_server.o ${SRC}
+system_server.o : ${SRCs} ${INCs}
+	${CC} ${CFLAGS_c} web_server.o ${SRCs}
 
 #3. clean
 clean :

--- a/web_server/web_server.c
+++ b/web_server/web_server.c
@@ -1,10 +1,9 @@
 #include <stdio.h>
 
-//#include <../system/system_server.h>
-#include <system_server.h>
-#include <gui.h>
-#include <input.h>
-#include <web_server.h>
+#include "./../system/system_server.h"
+#include "./../ui/gui.h"
+#include "./../ui/input.h"
+#include "web_server.h"
 
 int create_web_server()
 {


### PR DESCRIPTION
1. 모든 source file(*.c) 내부의 user-defined header file include 방식 수정
    => #include<>  -> #include""
    => source file 의 위치와 header file의 위치가 다른 경우에는 상대경로로 경로 지정
2. Makefile 수정
     => 2-1. ${SRC}와 ${INC} 분리(header file과 source file 분리해서 사용)
     => 2-2. header file은 target dependencies에는 포함 but, command 작성 시 (빌드 명렁어 작성) 컴파일 대상에서는 제외
     => 2-3. main.o를 포함하여 실행 file 만들기 전 단계에서는(sub directory에서 Makefile) linking 전까지만(.obj) 수행