### PR TITLE
Working

### DIFF
--- a/main.c
+++ b/main.c
@@ -2,6 +2,7 @@
 #include <sys/wait.h>
 #include <sys/signal.h>
 #include <errno.h>
+#include <pthread.h>
 
 #include "./system/system_server.h"
 #include "./ui/gui.h"
@@ -9,10 +10,21 @@
 #include "./web_server/web_server.h"
 #include "./project_libs/time/currTime.h"
 
+#define TOY_BUFFSIZE 1024
+
+
 /**
  * @note num of forked process
 */
 #define N 4;       
+
+
+/** global var : for TOY prompt in input.c
+ * 
+*/
+int TOY_prompt_operation_check = 0;
+pthread_mutex_t TOY_prompt_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t TOY_prompt_cond = PTHREAD_COND_INITIALIZER;
 
 /**
  * @note num of forked process
@@ -111,6 +123,19 @@ int main()
     waitpid(wpid, &chld_status, 0);
 */
     
+    /** lock() -> TOY_prompt_operation_check = 1 
+     * 
+    */
+    //pthread_mutex_lock(&global_message_mutex);
+    pthread_mutex_lock(&TOY_prompt_mutex);
+
+    TOY_prompt_operation_check = 1;
+
+    //pthread_mutex_unlock(&global_message_mutex);
+    pthread_mutex_unlock(&TOY_prompt_mutex);
+    pthread_cond_signal(&TOY_prompt_cond);
+
+
     /**
      * @note wait for SIGCHLD until all children are dead 
     */

--- a/main.c
+++ b/main.c
@@ -22,9 +22,11 @@
 /** global var : for TOY prompt in input.c
  * 
 */
+/*
 int TOY_prompt_operation_check = 0;
 pthread_mutex_t TOY_prompt_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_cond_t TOY_prompt_cond = PTHREAD_COND_INITIALIZER;
+*/
 
 /**
  * @note num of forked process
@@ -127,6 +129,7 @@ int main()
      * 
     */
     //pthread_mutex_lock(&global_message_mutex);
+    /*
     pthread_mutex_lock(&TOY_prompt_mutex);
 
     TOY_prompt_operation_check = 1;
@@ -134,7 +137,7 @@ int main()
     //pthread_mutex_unlock(&global_message_mutex);
     pthread_mutex_unlock(&TOY_prompt_mutex);
     pthread_cond_signal(&TOY_prompt_cond);
-
+    */
 
     /**
      * @note wait for SIGCHLD until all children are dead 


### PR DESCRIPTION
1.  ui/input.c에 command_thread, sensor_thread간 mutex lock 활용한 'TOY>'prompt mu 명령어 처리 기능 추가
+) mutex lock 사용하여 명령어 출력 결과 모두 끝나기 전까지 ‘TOY>’ 띄우지 않는 구현 추가 필요