### PR TITLE
14_mmap : elf file mapping 관련 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 #obj files
 *.o
+*.elf
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,10 @@
         "execinfo.h": "c",
         "stdio.h": "c",
         "toy_message.h": "c",
-        "shared_memory.h": "c"
+        "shared_memory.h": "c",
+        "mman.h": "c",
+        "semaphore.h": "c",
+        "currtime.h": "c",
+        "stat.h": "c"
     }
 }

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 #include <mqueue.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-
+#include <assert.h>
 #include "./system/system_server.h"
 #include "./ui/gui.h"
 #include "./ui/input.h"
@@ -66,13 +66,13 @@ static void sigchld_handler(int sig)
 /***************************************************************************************/
 
 
-/** feature : system_server proc 내에서 생성되는 threads들의 msg queue mqd저장
- * 
-*/
-#define MQ_NUM_MSG 10                //각 posix msg queue에 저장될 수 있는 msg 개수
-//#define MQ_MSG_SIZE 2048             //각 msg의 size(default : 8KB)
-#define NUM_OF_MQ 4                  //생성할 message queue file 개수
-#define FILE_MODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH) 
+// /** feature : system_server proc 내에서 생성되는 threads들의 msg queue mqd저장
+//  * 
+// */
+// #define MQ_NUM_MSG 10                //각 posix msg queue에 저장될 수 있는 msg 개수
+// #define MQ_MSG_SIZE 2048             //각 msg의 size(default : 8KB)
+// #define NUM_OF_MQ 4                  //생성할 message queue file 개수
+// #define FILE_MODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH) 
 /*
 static struct mq_attr watchdog_mq_attr;
 static struct mq_attr monitor_mq_attr;
@@ -174,13 +174,16 @@ int main()
 
     struct mq_attr attr;                        
     attr.mq_maxmsg = MQ_NUM_MSG;
-    attr.mq_msgsize = sizeof(toy_msg_t);
+    // attr.mq_msgsize = sizeof(toy_msg_t);
+    //attr.mq_msgsize = sizeof(MQ_MSG_SIZE);
+    attr.mq_msgsize = MQ_MSG_SIZE;
 
     //2. open : message queue create
     for(int i = 0; i <  NUM_OF_MQ; ++i)
     {
         // if(mqds[i] = mq_open(msg_queues_str[i], flags, perms, &attr) == -1) perror("mq_open");
-        if((mqds[i] = mq_open(msg_queues_str[i], flags, perms, &attr)) == -1) perror("mq_open");
+        mqds[i] = mq_open(msg_queues_str[i], flags, perms, &attr);
+        assert(mqds[i] != -1);
 
     }
 

--- a/project_libs/shared_memory.h
+++ b/project_libs/shared_memory.h
@@ -10,6 +10,7 @@ enum def_shm_key                        /* Key for shared memory segment */
 {
     SHM_KEY_BASE = 10,
     SHM_KEY_SENSOR = SHM_KEY_BASE,
+    SHM_KEY_CMD_R_FILE,
     SHM_KEY_MAX
 };
 
@@ -29,6 +30,7 @@ enum def_shm_key                        /* Key for shared memory segment */
 */
 #define SHMAT_FLAGS_R (SHM_RDONLY)       
 #define SHMAT_FLAGS_RW 0
+#define SHM_STR_MSG_BUF_SIZE 1024
 
 /* Defines structure of shared memory segment for sensor thread */
 typedef struct shm_sensor                                
@@ -38,6 +40,16 @@ typedef struct shm_sensor
     int humidity;
 } shm_sensor_t;
 
-extern int shm_id[SHM_KEY_MAX - SHM_KEY_BASE];
+
+/* Defines structure of shared memory segment for transfering string data */
+typedef struct shm_str_msg 
+{                 
+    int cnt;                    /* Number of bytes used in 'buf' */
+    char buf[SHM_STR_MSG_BUF_SIZE];         /* Data being transferred */
+} shm_str_msg_t;
+
+
+/* shm_id[SHM_KEY_MAX - 사용 key MACRO] : shmget() return value 저장 */
+//extern int shm_id[SHM_KEY_MAX - SHM_KEY_BASE];
 
 #endif /* _SHARED_MEMORY_H */

--- a/project_libs/toy_message.h
+++ b/project_libs/toy_message.h
@@ -3,6 +3,14 @@
 
 #include <unistd.h>
 
+/** feature : system_server proc 내에서 생성되는 threads들의 msg queue mqd저장
+ * 
+*/
+#define MQ_NUM_MSG 10                //각 posix msg queue에 저장될 수 있는 msg 개수
+#define MQ_MSG_SIZE 2048             //각 msg의 size(default : 8KB)
+#define NUM_OF_MQ 4                  //생성할 message queue file 개수
+#define FILE_MODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH) 
+
 typedef struct
 {
     unsigned int msg_type;
@@ -10,5 +18,7 @@ typedef struct
     unsigned int param2;
     void *param3;
 } toy_msg_t;
+
+
 
 #endif /* _TOY_MESSAGE_H_ */

--- a/ui/input.c
+++ b/ui/input.c
@@ -234,29 +234,31 @@ void *sensor_thread(void* arg)            //mutex
     enum def_shm_key shm_key = SHM_KEY_SENSOR;
     
 
+
+    /***************************************************************************************/
+    /******************************** SV shm 생성 + sensor_info 저장 - start ********************************/
+    /***************************************************************************************/
+
+    /** 1. shm segment 생성-1(shmget()) 
+     * @note shmget() 를 사용하여 shm 생성 + key값 얻기
+     * @return 생성된 shm segment's kev value(seg id) 
+    */
+    sensor_shm_key = shmget(shm_key, sizeof(shm_sensor_t), IPC_CREAT | SHMGET_FLAGS);
+    assert(sensor_shm_key != -1);
+
+    /** 2. shm segment 생성-2(shmgat()) 
+     * @note shmgat() 를 사용하여 address에 shm을 attach
+     * @note +) 프로세스가 종료될 때 자동으로 공유 메모리는 detach 된다.
+     * @note 2번째 argument NULL : kernel이 적절한(사용하지 않은) 주소를 붙임
+     * @return attached shm's address
+    */
+    the_sensor_info = (shm_sensor_t *)shmat(sensor_shm_key, NULL, SHMAT_FLAGS_RW);
+    assert((void *)the_sensor_info != (void *)-1); 
+
+
     while(1)
     {
         sleep(5);
-
-        /***************************************************************************************/
-        /******************************** SV shm 생성 + sensor_info 저장 - start ********************************/
-        /***************************************************************************************/
-
-        /** 1. shm segment 생성-1(shmget()) 
-         * @note shmget() 를 사용하여 shm 생성 + key값 얻기
-         * @return 생성된 shm segment's kev value(seg id) 
-        */
-        sensor_shm_key = shmget(shm_key, sizeof(shm_sensor_t), IPC_CREAT | SHMGET_FLAGS);
-        assert(sensor_shm_key != -1);
-
-        /** 2. shm segment 생성-2(shmgat()) 
-         * @note shmgat() 를 사용하여 address에 shm을 attach
-         * @note +) 프로세스가 종료될 때 자동으로 공유 메모리는 detach 된다.
-         * @note 2번째 argument NULL : kernel이 적절한(사용하지 않은) 주소를 붙임
-         * @return attached shm's address
-        */
-        the_sensor_info = (shm_sensor_t *)shmat(sensor_shm_key, NULL, SHMAT_FLAGS_RW);
-        assert((void *)the_sensor_info != (void *)-1); 
 
         /** 3. shm segment에 data 저장
          * @note the_sensor_info 사용하여 저장

--- a/ui/input.h
+++ b/ui/input.h
@@ -1,6 +1,26 @@
 #ifndef _INPUT_H
 #define _INPUT_H
 
+#include <stdint.h>
+
+typedef struct {
+  uint8_t     e_ident[16];         /* Magic number and other info */
+  uint16_t    e_type;              /* Object file type */
+  uint16_t    e_machine;           /* Architecture */
+  uint32_t    e_version;           /* Object file version */
+  uint64_t    e_entry;             /* Entry point virtual address */
+  uint64_t    e_phoff;             /* Program header table file offset */
+  uint64_t    e_shoff;             /* Section header table file offset */
+  uint32_t    e_flags;             /* Processor-specific flags */
+  uint16_t    e_ehsize;            /* ELF header size in bytes */
+  uint16_t    e_phentsize;         /* Program header table entry size */
+  uint16_t    e_phnum;             /* Program header table entry count */
+  uint16_t    e_shentsize;         /* Section header table entry size */
+  uint16_t    e_shnum;             /* Section header table entry count */
+  uint16_t    e_shstrndx;          /* Section header string table index */
+} Elf64Hdr;
+
+
 int create_input();
 
 #endif /* _INPUT_H */


### PR DESCRIPTION
1. system_server.c : elf file mapping 구현
2. input.c/sensor_thread(),  input.c/toy_read_elf_header() : semaphore + systemV shm + mqueue 사용한 IPC 구현